### PR TITLE
Fix undefined error when grid is removed from the DOM

### DIFF
--- a/src/GridContext.tsx
+++ b/src/GridContext.tsx
@@ -96,7 +96,17 @@ export function GridContextProvider({
    */
 
   function getFixedPosition(sourceId: string, rx: number, ry: number) {
-    const { left, top } = dropRefs.current.get(sourceId)!;
+    const item = dropRefs.current.get(sourceId)!;
+
+    // When items are removed from the DOM, the left and top values could be undefined.
+    if (!item) {
+      return {
+        x: rx,
+        y: ry
+      };
+    }
+
+    const { left, top } = item;
 
     return {
       x: left + rx,

--- a/src/GridDropZone.tsx
+++ b/src/GridDropZone.tsx
@@ -134,6 +134,8 @@ export function GridDropZone({
              */
 
             function onMove(state: StateType, x: number, y: number) {
+              if (!ref.current) return;
+
               if (draggingIndex !== i) {
                 setDraggingIndex(i);
               }


### PR DESCRIPTION
This kept happening to me when navigating away from the component rendering `react-grid-dnd`:

<img width="438" alt="Screen Shot 2019-11-01 at 12 15 13" src="https://user-images.githubusercontent.com/547148/68026129-00898680-fcaf-11e9-8f08-27dcb6983668.png">

The additional checks in this PR stopped the undefined error in `getFixedPosition` and `onMove`
