### PR TITLE
fix react-spring version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@types/react": "^16.8.10",
     "@types/react-dom": "^16.8.3",
-    "react-spring": "^9.0.0-beta.8",
+    "react-spring": "9.0.0-beta.8",
     "resize-observer-polyfill": "^1.5.1",
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
Hi I'm interested in using your library in my project and I found a problem with react-spring version in your package.json.

When I install your library, yarn, install the last version of react-spring 
![react-spring-updated-version](https://user-images.githubusercontent.com/37420305/71976090-c6d87d00-3215-11ea-945d-e9cc34a818c8.png)

This version breacks react-spring because _interpolate_ method is depecrated

![react-spring-deprecation](https://user-images.githubusercontent.com/37420305/71976200-03a47400-3216-11ea-8df4-e3fcf615755b.png)

Then the animations are not working
![gridlayoutLAG](https://user-images.githubusercontent.com/37420305/71976216-1028cc80-3216-11ea-8f40-c0f7cc6f180d.gif)

But if you specify react-spring version to 9.0.0-beta.8 in your package.json, it will install this version exactly and work as expexted.

![gridlayoutOK](https://user-images.githubusercontent.com/37420305/71976308-47977900-3216-11ea-827f-34d6da4744db.gif)

This has probably happened because when you did the _yarn add_ there was no other version of react-spring beta

Two possible solutions are:  force to install this version or update your code with the newest version