### PR TITLE
Fixed GridItem's className functionality

### DIFF
--- a/src/GridItem.tsx
+++ b/src/GridItem.tsx
@@ -141,12 +141,9 @@ export function GridItem({
 
   const props = {
     className:
-      "GridItem" +
+      (className ? className : "GridItem") +
       (isDragging ? " dragging" : "") +
-      (!!disableDrag ? " disabled" : "") +
-      className
-        ? ` ${className}`
-        : "",
+      (!!disableDrag ? " disabled" : ""),
     ...bind,
     style: {
       cursor: !!disableDrag ? "grab" : undefined,


### PR DESCRIPTION
The className functionality of GridItem is currently broken. 
As the "dragging" and "disabled" checks were on the left side of the className ternary, these were being used to evaluate, but were never being added to the className. This also always evaluated to true due to the "GridItem" string.

Additionally, providing no className to the GridItem component caused a className of " undefined" to appear in the DOM due to the false positive within the ternary check.
This change makes GridItem use either the provided className or a default of "GridItem", and both will have "dragging" or "disabled" appended to it when necessary.