### PR TITLE
Disable Single Grid Item

### DIFF
--- a/src/GridItem.tsx
+++ b/src/GridItem.tsx
@@ -9,12 +9,14 @@ import { GridItemContext } from "./GridItemContext";
 
 interface GridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
+  disabled?: boolean;
 }
 
 export function GridItem({
   children,
   style,
   className,
+  disabled=false,
   ...other
 }: GridItemProps) {
   const context = React.useContext(GridItemContext);
@@ -96,7 +98,7 @@ export function GridItem({
   const { bind } = useGestureResponder(
     {
       onMoveShouldSet: state => {
-        if (disableDrag) {
+        if (disabled || disableDrag) {
           return false;
         }
 

--- a/stories/intro.stories.tsx
+++ b/stories/intro.stories.tsx
@@ -245,7 +245,8 @@ storiesOf("Hello", module)
       <TransformExample />
     </div>
   ))
-  .add("readme example", () => <ReadmeExample />);
+  .add("readme example", () => <ReadmeExample />)
+  .add("disable single item", () => <DisabledExample />);
 
 function TransformExample() {
   const [transform, setTransform] = React.useState(false);
@@ -299,6 +300,47 @@ function ReadmeExample() {
               }}
             >
               {item}
+            </div>
+          </GridItem>
+        ))}
+      </GridDropZone>
+    </GridContextProvider>
+  );
+}
+
+function DisabledExample() {
+  const [items, setItems] = React.useState([1, 2, 3, 4]); // supply your own state
+
+  // target id will only be set if dragging from one dropzone to another.
+  function onChange(
+    sourceId: any,
+    sourceIndex: any,
+    targetIndex: any,
+    targetId: any
+  ) {
+    const nextState = swap(items, sourceIndex, targetIndex);
+    setItems(nextState);
+  }
+
+  return (
+    <GridContextProvider onChange={onChange}>
+      <GridDropZone
+        id="items"
+        boxesPerRow={4}
+        rowHeight={100}
+        style={{ height: "400px" }}
+      >
+        {items.map((item: any) => (
+          //only disable 2
+          <GridItem key={item} disabled={item === 2}>
+            <div
+              style={{
+                width: "100%",
+                height: "100%",
+              }}
+            >
+              {item}
+              {item === 2 ? "(Disabled)" : ""}
             </div>
           </GridItem>
         ))}


### PR DESCRIPTION
Re: https://github.com/bmcmahen/react-grid-dnd/issues/8
`onMouseDown = {(e) => e.stopPropagation ()}` wasn't sufficient for my use case where I need to move between two states of grid item one that is "active" and "non-active". 

Feel free to update or provide feedback. I added a small story to test this feature. 